### PR TITLE
Update for a modern Mac OS and fix OpenGL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,6 @@ include_directories("include")
 find_package(OpenGL REQUIRED)
 find_package(GLFW3 REQUIRED)
 find_package(glm REQUIRED)
-find_package(GLEW REQUIRED)
-
-if (GLEW_FOUND)
-    include_directories(${GLEW_INCLUDE_DIRS})
-    link_libraries(${GLEW_LIBRARIES})
-endif()
 
 add_executable(clion_modern_opengl ${SOURCE_FILES})
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Brew has up-to-date versions of all three dependencies.
 
 ```
 brew update
-brew install glfw glew glm
+brew install glfw glm
 ```
 
 ### Windows

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # clion-modern-opengl
-CLion starting point (boilerplate) for creating modern OpenGL applications in C++ in MacOS, Windows, and Linux.
 
 The current scene contains a spinning triangle whose colour varies over time. You can zoom in and out of the scene by left-clicking and dragging on the window.
 
@@ -12,23 +11,13 @@ Plumbing includes use of a VAO, a VBO, GLFW callbacks, uniform variables, and a 
 
 ## Instructions
 
-Clion uses CMake which should simplify using GLFW3, GLEW, and GLM.
-
-⚠️ Be sure to set the correct working directory for the current build configuration in CLion.
+Clion uses CMake which should simplify using GLFW3 and GLM.
 
 ### MacOS
 
-Brew has up-to-date versions of all three dependencies.
+Brew has up-to-date versions of those dependencies.
 
 ```
 brew update
 brew install glfw glm
 ```
-
-### Windows
-
-(coming soon!)
-
-### Linux
-
-(coming soon!)

--- a/include/GLSLProgram.h
+++ b/include/GLSLProgram.h
@@ -2,7 +2,7 @@
 #define CLION_MODERN_OPENGL_GLSLPROGRAM_H
 
 #include <string>
-#include <GL/glew.h>
+#include <OpenGL/gl3.h>
 #include "glm/mat4x2.hpp"
 
 using std::string;

--- a/src/cpp/App.cpp
+++ b/src/cpp/App.cpp
@@ -1,4 +1,4 @@
-#include <GL/glew.h>
+#include <OpenGL/gl3.h>
 #include <GLFW/glfw3.h>
 #include <GLSLProgram.h>
 
@@ -76,13 +76,6 @@ int main()
     glfwSetFramebufferSizeCallback(window, framebuffer_size_callback);
     glfwSetCursorPosCallback(window, cursor_pos_callback);
     glfwMakeContextCurrent(window);
-
-    glewExperimental = GL_TRUE;
-
-    if (glewInit() != GLEW_OK)
-    {
-        exit(1);
-    }
 
     shaderProgram = new GLSLProgram();
 

--- a/src/cpp/App.cpp
+++ b/src/cpp/App.cpp
@@ -130,7 +130,7 @@ int main()
 
         GLfloat now = (GLfloat)glfwGetTime();
 
-        triangle_model_matrix = glm::rotate(glm::mat4(), (float)sin(now), glm::vec3(0.0f, 0.0f, 1.0f));
+        triangle_model_matrix = glm::rotate(glm::mat4(1.0f), (float)sin(now), glm::vec3(0.0f, 0.0f, 1.0f));
         view_matrix = glm::lookAt(camera_position, glm::vec3(0.0f), glm::vec3(0.0f, 1.0f, 0.0f));
 
         shaderProgram->setUniform("model_matrix", triangle_model_matrix);


### PR DESCRIPTION
GLEW is not working well with modern Mac OS so I have to remove it.
`glm::mat4()` no longer create a indentity matrix now you need to use `glm::mat4(1.0f)`